### PR TITLE
Add POD attn bench

### DIFF
--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -579,8 +579,7 @@ class PODWithPagedKVCacheWrapper:
             window_left_d != -1,  # use_sliding_window
             logits_soft_cap_d > 0,  # use_logits_soft_cap
         )
-        print(f"v_p.shape: {v_p.shape}")
-        print(f"v_cache_d.shape: {v_cache_d.shape}")
+
         module_getter.run_tensor(
             # Prefill params
             q_p,

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -579,6 +579,8 @@ class PODWithPagedKVCacheWrapper:
             window_left_d != -1,  # use_sliding_window
             logits_soft_cap_d > 0,  # use_logits_soft_cap
         )
+        print(f"v_p.shape: {v_p.shape}")
+        print(f"v_cache_d.shape: {v_cache_d.shape}")
         module_getter.run_tensor(
             # Prefill params
             q_p,


### PR DESCRIPTION
* Add benchmark of POD Attn vs Persistent Batched attention. This confirms that POD Attention is much slower. 
* I'm trying to debug its performance these days, but not sure why it could be suffering from the wave straggler issue solved in the persistent scheduler. 
  * According to the paper, it should alleviate wave quantization and launch the next CTA whenever an SM has free resources? I also don't see global barriers in https://github.com/flashinfer-ai/flashinfer/blob/main/include/flashinfer/attention/pod.cuh
<img width="713" alt="image" src="https://github.com/user-attachments/assets/c17b1789-9938-4e34-b606-2515fc17f304" />

cc @yzh119 @AKKamath welcome any suggestions 🥹